### PR TITLE
Enhance README formatting and add objectOf decoder functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonous",
-  "version": "10.0.0",
+  "version": "11.0.0",
   "description": "Type safe JSON decoding for JavaScript",
   "author": "Ryan L. Bell <ryan.l.bell@gmail.com>",
   "license": "MIT",

--- a/readme.md
+++ b/readme.md
@@ -35,6 +35,7 @@ yarn add jsonous
    Jsonous uses the Result type (from the resulty library) to represent the outcome of a decoding operation. A Result can be either:
 
    Ok(value): Indicates successful decoding, containing the decoded value.
+
    Err(message): Indicates a decoding failure, containing an error message.
 
 3. _Composable Decoders_

--- a/readme.md
+++ b/readme.md
@@ -35,7 +35,6 @@ yarn add jsonous
    Jsonous uses the Result type (from the resulty library) to represent the outcome of a decoding operation. A Result can be either:
 
    Ok(value): Indicates successful decoding, containing the decoded value.
-
    Err(message): Indicates a decoding failure, containing an error message.
 
 3. _Composable Decoders_

--- a/src/associative.ts
+++ b/src/associative.ts
@@ -87,14 +87,11 @@ export const dict = <A>(decoder: Decoder<A>): Decoder<Map<string, A>> =>
 export function objectOf<T>(valueDecoder: Decoder<T>): Decoder<{ [key: string]: T }> {
   return new Decoder<{ [key: string]: T }>((value) => {
     if (typeof value !== 'object' || value === null || Array.isArray(value)) {
-      return err(`I expected to find an object but instead found ${typeof value}`);
+      return err(`I expected to find an object but instead found '${safeStringify(value)}'`);
     }
 
     const result: { [key: string]: T } = {};
     for (const key in value) {
-      if (typeof key !== 'string') {
-        return err(`I expected all keys to be strings, but found a non-string key: ${key}`);
-      }
       const decodedValue = valueDecoder.decodeAny(value[key]);
       if (decodedValue.state.kind === 'err') {
         return err(

--- a/src/associative.ts
+++ b/src/associative.ts
@@ -45,3 +45,66 @@ export const dict = <A>(decoder: Decoder<A>): Decoder<Map<string, A>> =>
       return memo;
     }, new Map<string, A>())
   );
+
+/**
+ * Creates a decoder for objects where all keys are strings and all values
+ * conform to a specific type.
+ *
+ * This function is a higher-order decoder factory. It takes a `valueDecoder`
+ * as an argument, which is responsible for decoding the individual values
+ * within the object. The `objectOf` function then creates a new decoder that
+ * can decode an entire object, ensuring that all keys are strings and all
+ * values are successfully decoded by the provided `valueDecoder`.
+ *
+ * @param valueDecoder - A decoder that will be used to decode each value
+ *   within the object. This decoder determines the type of the values in the
+ *   resulting object.
+ * @returns A decoder that can decode objects with string keys and values
+ *   of the type specified by `valueDecoder`.
+ *
+ * @example
+ * ```typescript
+ * import { string, number, objectOf } from './associative'; // Assuming these are in the same file
+ * import { InferType } from './base'; // Assuming InferType is defined in base.ts
+ *
+ * // Decoder for an object where values are strings
+ * const stringObjectDecoder = objectOf(string);
+ * type StringObject = InferType<typeof stringObjectDecoder>;
+ *
+ * // Decoder for an object where values are numbers
+ * const numberObjectDecoder = objectOf(number);
+ * type NumberObject = InferType<typeof numberObjectDecoder>;
+ *
+ * // Example usage
+ * const validStringObject: StringObject = { a: 'hello', b: 'world' };
+ * const validNumberObject: NumberObject = { x: 1, y: 2, z: 3 };
+ *
+ * // Example of invalid data
+ * const invalidStringObject = { a: 'hello', b: 123 }; // Error: 'b' is not a string
+ * const invalidNumberObject = { x: 1, y: '2', z: 3 }; // Error: 'y' is not a number
+ * ```
+ */
+export function objectOf<T>(valueDecoder: Decoder<T>): Decoder<{ [key: string]: T }> {
+  return new Decoder<{ [key: string]: T }>((value) => {
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+      return err(`I expected to find an object but instead found ${typeof value}`);
+    }
+
+    const result: { [key: string]: T } = {};
+    for (const key in value) {
+      if (typeof key !== 'string') {
+        return err(`I expected all keys to be strings, but found a non-string key: ${key}`);
+      }
+      const decodedValue = valueDecoder.decodeAny(value[key]);
+      if (decodedValue.state.kind === 'err') {
+        return err(
+          `I expected the value for key "${key}" to be a valid value, but found: ${safeStringify(
+            value[key]
+          )}`
+        );
+      }
+      result[key] = decodedValue.state.value;
+    }
+    return ok(result);
+  });
+}

--- a/src/associative.ts
+++ b/src/associative.ts
@@ -91,7 +91,7 @@ export function objectOf<T>(valueDecoder: Decoder<T>): Decoder<{ [key: string]: 
     }
 
     const result: { [key: string]: T } = {};
-    for (const key in value) {
+    for (const key of Object.keys(value)) {
       const decodedValue = valueDecoder.decodeAny(value[key]);
       if (decodedValue.state.kind === 'err') {
         return err(

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ export { boolean, fail, number, string, succeed } from './base';
 export { array, at, field } from './containers';
 
 // Associative Decoders
-export { dict, keyValuePairs } from './associative';
+export { dict, keyValuePairs, objectOf } from './associative';
 
 // Presence Decoders
 export { maybe, nullable } from './presence';

--- a/tests/objectOf.spec.ts
+++ b/tests/objectOf.spec.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'bun:test';
+import { Result } from 'resulty';
+import { objectOf } from '../src/associative';
+import { boolean, number, string } from '../src/base';
+import { InferType } from '../src/types';
+
+// Helper function to check for errors
+function expectError<T>(result: Result<string, T>, expectedError: string) {
+  result.cata({
+    Err: (e) => expect(e).toBe(expectedError),
+    Ok: () => {
+      console.error('Expected error but got success:', result);
+      expect(true).toBe(false);
+    },
+  });
+}
+
+// Helper function to check for success
+function expectSuccess<T>(result: Result<string, T>, expectedValue: T) {
+  result.cata({
+    Err: (msg) => {
+      console.error('Expected success but got error:', msg);
+      expect(true).toBe(false);
+    },
+    Ok: (v) => expect(v).toEqual(expectedValue),
+  });
+}
+
+describe('associative', () => {
+  describe('objectOf', () => {
+    // Example usage with string values (like DecadeDataRow)
+    const decadeDataRowDecoder = objectOf(string);
+    type DecadeDataRow = InferType<typeof decadeDataRowDecoder>;
+
+    // Example usage with number values
+    const numberObjectDecoder = objectOf(number);
+    type NumberObject = InferType<typeof numberObjectDecoder>;
+
+    // Example usage with boolean values
+    const booleanObjectDecoder = objectOf(boolean);
+    type BooleanObject = InferType<typeof booleanObjectDecoder>;
+
+    it('should succeed with a valid DecadeDataRow', () => {
+      const validData: DecadeDataRow = {
+        key1: 'value1',
+        key2: 'value2',
+        key3: 'value3',
+      };
+      expectSuccess(decadeDataRowDecoder.decodeAny(validData), validData);
+    });
+
+    it('should fail with a non-object', () => {
+      expectError(
+        decadeDataRowDecoder.decodeAny('hello'),
+        'I expected to find an object but instead found string'
+      );
+      expectError(
+        decadeDataRowDecoder.decodeAny(123),
+        'I expected to find an object but instead found number'
+      );
+      expectError(
+        decadeDataRowDecoder.decodeAny(true),
+        'I expected to find an object but instead found boolean'
+      );
+      expectError(
+        decadeDataRowDecoder.decodeAny(null),
+        'I expected to find an object but instead found object'
+      );
+      expectError(
+        decadeDataRowDecoder.decodeAny(undefined),
+        'I expected to find an object but instead found undefined'
+      );
+      expectError(
+        decadeDataRowDecoder.decodeAny([]),
+        'I expected to find an object but instead found object'
+      );
+    });
+
+    it('should fail if a value is not a string', () => {
+      expectError(
+        decadeDataRowDecoder.decodeAny({ key1: 123 }),
+        'I expected the value for key "key1" to be a valid value, but found: 123'
+      );
+      expectError(
+        decadeDataRowDecoder.decodeAny({ key1: true }),
+        'I expected the value for key "key1" to be a valid value, but found: true'
+      );
+      expectError(
+        decadeDataRowDecoder.decodeAny({ key1: null }),
+        'I expected the value for key "key1" to be a valid value, but found: null'
+      );
+      expectError(
+        decadeDataRowDecoder.decodeAny({ key1: undefined }),
+        'I expected the value for key "key1" to be a valid value, but found: undefined'
+      );
+      expectError(
+        decadeDataRowDecoder.decodeAny({ key1: {} }),
+        'I expected the value for key "key1" to be a valid value, but found: {}'
+      );
+      expectError(
+        decadeDataRowDecoder.decodeAny({ key1: [] }),
+        'I expected the value for key "key1" to be a valid value, but found: []'
+      );
+    });
+
+    it('should succeed with a valid NumberObject', () => {
+      const validData: NumberObject = {
+        key1: 1,
+        key2: 2,
+        key3: 3,
+      };
+      expectSuccess(numberObjectDecoder.decodeAny(validData), validData);
+    });
+
+    it('should fail if a value is not a number', () => {
+      expectError(
+        numberObjectDecoder.decodeAny({ key1: '123' }),
+        'I expected the value for key "key1" to be a valid value, but found: "123"'
+      );
+    });
+
+    it('should succeed with a valid BooleanObject', () => {
+      const validData: BooleanObject = {
+        key1: true,
+        key2: false,
+        key3: true,
+      };
+      expectSuccess(booleanObjectDecoder.decodeAny(validData), validData);
+    });
+
+    it('should fail if a value is not a boolean', () => {
+      expectError(
+        booleanObjectDecoder.decodeAny({ key1: 'true' }),
+        'I expected the value for key "key1" to be a valid value, but found: "true"'
+      );
+    });
+  });
+});

--- a/tests/objectOf.spec.ts
+++ b/tests/objectOf.spec.ts
@@ -52,27 +52,27 @@ describe('associative', () => {
     it('should fail with a non-object', () => {
       expectError(
         decadeDataRowDecoder.decodeAny('hello'),
-        'I expected to find an object but instead found string'
+        'I expected to find an object but instead found \'"hello"\''
       );
       expectError(
         decadeDataRowDecoder.decodeAny(123),
-        'I expected to find an object but instead found number'
+        "I expected to find an object but instead found '123'"
       );
       expectError(
         decadeDataRowDecoder.decodeAny(true),
-        'I expected to find an object but instead found boolean'
+        "I expected to find an object but instead found 'true'"
       );
       expectError(
         decadeDataRowDecoder.decodeAny(null),
-        'I expected to find an object but instead found object'
+        "I expected to find an object but instead found 'null'"
       );
       expectError(
         decadeDataRowDecoder.decodeAny(undefined),
-        'I expected to find an object but instead found undefined'
+        "I expected to find an object but instead found 'undefined'"
       );
       expectError(
         decadeDataRowDecoder.decodeAny([]),
-        'I expected to find an object but instead found object'
+        "I expected to find an object but instead found '[]'"
       );
     });
 


### PR DESCRIPTION
Improve the README for better clarity on core concepts and decoding sections. Introduce a new `objectOf` decoder for objects with string keys and specified value types, along with comprehensive tests to ensure its functionality.